### PR TITLE
Allow disabling and switching between heating/cooling live.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -679,32 +679,15 @@ Comment out this error to acknowledge this disclaimer and allow compilation."
 #endif
 
 /*
-* MarlinBio:
-* The target temperatures for the syringe/bed modules.
-* Only COOLER_X_TARGET or HEATER_X_TARGET can be enabled for each module.
-* Disable both if not using the temperature module. Cooler/heater 4 is the bed.
-* If you want temperature control enabled, but want to temporarily turn it off,
-* set the temperature to something like 100°C for cooling or 0°C for heating.
-* The M104 command can also be used to set the targets, but not change between heating/cooling.
-* The M109 command is not supported.
-* WARNING: The peltier must be connected in the correct direction for heating or cooling.
-* WARNING: Always rewire with the power completely disconnected.
+ * The temperature modules start in a disabled state. To enable them to heat or cool,
+ * set a target temperature, or disable them when finished, use the M104 command.
+ * It is not recommended to switch between heating and cooling while the device is powered,
+ * as this requires rewiring, but can be done by first disabling the module.
+ * The M109 command is not supported.
+ * Module 4 is the bed.
+ * WARNING: The peltier must be connected in the correct direction for heating or cooling.
+ * WARNING: Always rewire with the power completely disconnected.
  */
-//#define COOLER_0_TARGET 0
-//#define HEATER_0_TARGET 50
-
-//#define COOLER_1_TARGET 0
-//#define HEATER_1_TARGET 50
-
-//#define COOLER_2_TARGET 0
-//#define HEATER_2_TARGET 50
-
-//#define COOLER_3_TARGET 0
-//#define HEATER_3_TARGET 50
-
-/// MarlinBio: This is the bed.
-//#define COOLER_4_TARGET 0
-//#define HEATER_4_TARGET 50
 
 /// MarlinBio: A fatal error will be issued below this temperature.
 #define HEATER_0_MINTEMP -15
@@ -721,13 +704,24 @@ Comment out this error to acknowledge this disclaimer and allow compilation."
 #define HEATER_4_MAXTEMP 75
 
 /*
- * MarlinBio:
  * Thermal Overshoot.
  * During operation, the temperature can often "overshoot" the target by many degrees.
  * Setting the target temperature too close to MAXTEMP/MINTEMP guarantees a shutdown!
- * Use this value to forbid temperatures being set over/under MAXTEMP/MINTEMP -/+ OVERSHOOT.
+ * Use this value to block temperatures being set over/under MAXTEMP/MINTEMP -/+ OVERSHOOT.
  */
 #define HOTEND_OVERSHOOT 15
+
+/*
+ * Dampen the fans upon reaching the target.
+ * When auto fans are enabled, the fans will run at a certain speed depending on the target
+ * temperature. Once the target is reached and the temperature only needs to be maintained,
+ * the fan speed can be reduced for noise tolerance. This is the PWM that will be set upon
+ * reaching the target. Set it lower if the noise is bothersome, and higher if the conditions
+ * cause the temperature to become unstable. M106 can also be used to disable the auto fan feature
+ * entirely and allow manual control.
+ * 0 - 255.
+ */
+#define AUTO_FAN_DAMPEN 128
 
 //===========================================================================
 //============================= PID Settings ================================
@@ -742,7 +736,8 @@ Comment out this error to acknowledge this disclaimer and allow compilation."
  * PIDTEMP : PID temperature control (~4.1K)
  * MPCTEMP : Predictive Model temperature control. (~1.8K without auto-tune)
  */
-/// MarlinBio: Peltier's don't like PWM, so we run them continuously until they reach the target.
+/// MarlinBio: The efficiency and lifespan of a peltier is decreased with PWM,
+/// so we run them continuously until they reach the target.
 //#define PIDTEMP           // See the PID Tuning Guide at https://reprap.org/wiki/PID_Tuning
 //#define MPCTEMP         // See https://marlinfw.org/docs/features/model_predictive_control.html
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -331,8 +331,10 @@
    * and/or decrease WATCH_TEMP_INCREASE. WATCH_TEMP_INCREASE should not be set
    * below 2.
    */
-  #define WATCH_TEMP_PERIOD  40               // (seconds)
+  #define WATCH_HEAT_PERIOD  30               // (seconds)
+  #define WATCH_COOL_PERIOD  60               // (seconds)
   #define WATCH_TEMP_INCREASE 2               // (°C)
+  #define WATCH_TEMP_DECREASE 0.5               // (°C)
 #endif
 
 /**

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -381,7 +381,7 @@ void startOrResumeJob() {
 
     IF_DISABLED(SD_ABORT_NO_COOLDOWN, thermalManager.disable_all_heaters());
 
-    TERN(HAS_CUTTER, cutter.kill(), thermalManager.zero_fan_speeds()); // Full cutter shutdown including ISR control
+    TERN_(HAS_CUTTER, cutter.kill()); // Full cutter shutdown including ISR control
 
     wait_for_heatup = false;
 

--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -247,7 +247,7 @@
 #define STR_REDUNDANT                       "redundant "
 #define STR_LASER_TEMP                      "laser temperature"
 
-#define STR_STOPPED_HEATER                  ", system stopped! Heater_ID: "
+#define STR_STOPPED_HEATER                  ", system stopped! Check your settings and connections. Module ID: "
 #define STR_DETECTED_TEMP_B                 " (temp: "
 #define STR_DETECTED_TEMP_E                 ")"
 #define STR_REDUNDANCY                      "Heater switched off. Temperature difference between temp sensors is too high !"

--- a/Marlin/src/gcode/feature/constant_extrusion/M789.cpp
+++ b/Marlin/src/gcode/feature/constant_extrusion/M789.cpp
@@ -31,12 +31,12 @@
  * If no parameters are provided, it reports the current settings.
  * If any parameter is provided, it will enable constant extrusion unless 'D' is specified.
  * 
- *  E : Extruder index (default: active_extruder)
- *  S : Syringe inner diameter (mm)
- *  N : Needle inner diameter (mm)
- *  K : Extrusion coefficient
- *  P : Pressurization length (mm)
- *  D : Disable constant extrusion (default: enabled)
+ *  E : Extruder index (default: active_extruder).
+ *  S : Syringe inner diameter (mm).
+ *  N : Needle inner diameter (mm).
+ *  K : Extrusion coefficient.
+ *  P : Pressurization length (mm).
+ *  D : Disable constant extrusion (default: enabled).
  *
  * Examples:
  *   M789                             ; Report current parameters

--- a/Marlin/src/gcode/feature/mixing/M163-M165.cpp
+++ b/Marlin/src/gcode/feature/mixing/M163-M165.cpp
@@ -28,15 +28,16 @@
  * MarlinBio:
  * M163: Set mixing extruder ratios.
  * 
- * This command sets the ratios for mixing extruders.
- * If no parameters are provided, it reports the current settings.
+ * This command sets the ratios for mixing extruders. The ratio simply scales
+ * extrusion; for example, a specified extrusion of 3mm for an extruder with a ratio of
+ * 0.5 will extrude 1.5mm. If no parameters are provided, it reports the current settings.
  * 
- *  S : Extruder index
- *  P : Syringe inner diameter (mm)
+ *  E : Extruder index.
+ *  R : Ratio.
  *
  * Examples:
- *   M163.         ; Report current parameters
- *   M163 S2 P0.66 ; Set the ratio for the third extruder to 0.66.
+ *   M163          ; Report the current parameters.
+ *   M163 E2 R0.66 ; Set the ratio for the third extruder to 0.66.
  */
 void GcodeSuite::M163() {
   if (!parser.seen_any()) {
@@ -45,18 +46,18 @@ void GcodeSuite::M163() {
     return;
   }
 
-  if (!parser.seenval('S')) {
-    SERIAL_ECHOLN("The extruder index, S, is required");
+  if (!parser.seenval('E')) {
+    SERIAL_ECHOLN("The extruder index, E, is required");
     return;
   }
-  const uint8_t extruder = parser.intval('S');
+  const uint8_t extruder = parser.intval('E');
   if (extruder >= EXTRUDERS) {
     SERIAL_ECHOLN("Invalid extruder index");
     return;
   }
 
-  if (!parser.seenval('P')) {
-    SERIAL_ECHOLN("The mix ratio, P, is required");
+  if (!parser.seenval('R')) {
+    SERIAL_ECHOLN("The mix ratio, R, is required");
     return;
   }
   const float mix_ratio = parser.value_float();

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -595,7 +595,7 @@ void GcodeSuite::process_parsed_command(bool no_ok/*=false*/) {
 
       #if HAS_FAN
         case 106: M106(); break;                                  // M106: Fan On
-        case 107: M107(); break;                                  // M107: Fan Off
+        //case 107: M107(); break;                                  // M107: Fan Off
       #endif
 
       case 110: M110(); break;                                    // M110: Set Current Line Number

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -778,7 +778,9 @@ private:
 
   #if HAS_FAN
     static void M106();
-    static void M107();
+    static void M106_report(const bool forReplay=true);
+    /// MarlinBio: M107 is a pointless command, use M106.
+    //static void M107();
   #endif
 
   #if DISABLED(EMERGENCY_PARSER)

--- a/Marlin/src/gcode/temp/M104_M109.cpp
+++ b/Marlin/src/gcode/temp/M104_M109.cpp
@@ -24,37 +24,78 @@
 #include "../gcode.h"
 #include "../../module/temperature.h"
 
-/**
+/*
  * MarlinBio:
- * M104: Set temperature module target.
+ * M104: Set temperature module type and target.
+ * 
+ * This command can set a temperature module to heat or cool to a target
+ * temperature, or disable it. Using D without specifying a module will
+ * disable all modules. A module can only go from disabled to heating or
+ * cooling, or from heating or cooling to disabled. 
  *
- * Parameters
- *  T<index>  : Temperature module index.
- *  S<target> : The target temperature in celsius.
+ *  I : Module index selector.
+ *  T : Target temperature (°C).
+ *  D : Disable. If no index is specified, disable all.
+ *  H : Specify heating.
+ *  C : Specify cooling.
  *
  * Examples
- *  M104 T1 S60 : Set the second temperature module to 60°.
+ *   M104 I1 H T50 ; Set the second temperature module to heat to 50°C.
+ *   M104 I1 T60   ; Set the second temperature module to 60°C, still heating.
+ *   M104 I0 T4    ; Set the first temperature module to cool to 4°C.
+ *   M104 I0 D     ; Disable the first temperature module.
  */
 void GcodeSuite::M104_M109(const bool isM109) {
-  /// MarlinBio: A lot of the original fluff was removed. It simply sets the temperature
-  /// for the specified module now.
-  /// Leaving the parameters as T and S to avoid differences with the Marlin documentation.
-  /// Though E(xtruder) or H(otend) and T(emperature) are obviously better choices.
-  const uint8_t module = parser.byteval('T', UINT8_MAX);
-  if (module >= HOTENDS) {
-    SERIAL_ECHOLN("Invalid temperature module index");
+  bool disable = parser.seen('D');
+  bool indexed = parser.seenval('I');
+
+  if (!indexed && !disable) {
+    SERIAL_ECHOLN("A module index is required, except when disabling everything using D.");
+    return;
+  }
+
+  uint8_t index;
+  if (indexed) {
+    index = parser.value_byte();
+    if (index >= HOTENDS) {
+      SERIAL_ECHOLN("Invalid temperature module index.");
+      return;
+    }
+  }
+
+  if (disable) {
+    if (indexed) {
+      thermalManager.disable_heater(index);
+    } else {
+      thermalManager.disable_all_heaters();
+    }
+
+    /// MarlinBio: When D is specified, do nothing else.
     return;
   }
 
   celsius_float_t temp;
-  if (parser.seenval('S')) {
+  if (parser.seenval('T')) {
     temp = parser.value_celsius();
   } else {
-    SERIAL_ECHOLN("A temperature is required");
+    SERIAL_ECHOLN("A target temperature is required.");
     return;
   }
 
-  thermalManager.setTargetHotend(temp, module);
+  if (parser.seen('H') && parser.seen('C')) {
+    SERIAL_ECHOLN("Only heating OR cooling can be specified.");
+    return;
+  } else if (parser.seen('H') || parser.seen('C')) {
+    if (!thermalManager.setTypeHotend(parser.seen('H') ? hotend_info_t::deviceType::heater : hotend_info_t::deviceType::cooler, index)) {
+      return;
+    }
+  }
+
+  if (thermalManager.temp_hotend[index].enabled()) {
+    thermalManager.setTargetHotend(temp, index);
+  } else {
+    SERIAL_ECHOLN("Module ", index, " is not enabled. Use H or C to set it to heating or cooling after ensuring the module is wired in the correct orientation.");
+  }
 }
 
 #endif // HAS_HOTEND

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -1,9 +1,6 @@
 /**
- * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
- *
- * Based on Sprinter and grbl.
- * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ * MarlinBio 3D Printer Firmware
+ * Copyright (c) 2025 MarlinBio [https://github.com/twrankin/MarlinBio]
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,89 +25,81 @@
 #include "../../module/motion.h"
 #include "../../module/temperature.h"
 
-#if ENABLED(LASER_SYNCHRONOUS_M106_M107)
-  #include "../../module/planner.h"
-#endif
-
-#if HAS_PREHEAT
-  #include "../../lcd/marlinui.h"
-#endif
-
-#if ENABLED(SINGLENOZZLE)
-  #define _ALT_P active_extruder
-  #define _CNT_P EXTRUDERS
-#else
-  #define _ALT_P _MIN(active_extruder, FAN_COUNT - 1)
-  #define _CNT_P FAN_COUNT
-#endif
-
-/**
- * M106: Set Fan Speed
+/*
+ * MarlinBio:
+ * M106: Set PWM.
+ * 
+ * This command sets the duty cycle for a pulse width modulation header. This
+ * is typically used for fans, but can also be used for other devices that accept
+ * PWM, such as LEDs. Any command that changes the PWM will disable the auto fan
+ * functionality for that header until reenabled.
+ * If no parameters are specified, it reports the current settings.
  *
- * Parameters:
- *   I<index>  Material Preset index (if material presets are defined)
- *   S<int>    Speed between 0-255
- *   P<index>  Fan index, if more than one fan
+ *  I<index> : Header index selector.
+ *  P<PWM>   : Target PWM (0 - 255).
+ *  A<auto>  : Enable auto fan mode (default: enabled).
  *
- * With EXTRA_FAN_SPEED:
- *   T<int>  Restore/Use/Set Temporary Speed:
- *     T1      Restore previous speed after T2
- *     T2      Use temporary speed set with T3-255
- *     T3-255  Set the speed for use with T2
+ * Examples
+ *  M106         ; Report current parameters
+ *  M106 I1 P255 ; Set the second module to full PWM.
+ *  M106 I3 P0   ; Turn the fourth module off.
  */
 void GcodeSuite::M106() {
-  const uint8_t pfan = parser.byteval('P', _ALT_P);
-  if (pfan >= _CNT_P) return;
-  if (FAN_IS_REDUNDANT(pfan)) return;
+  if (!parser.seen_any()) {
+    /// MarlinBio: Report the current parameters and return.
+    M106_report();
+    return;
+  }
 
-  #if ENABLED(EXTRA_FAN_SPEED)
-    const uint16_t t = parser.intval('T');
-    if (t > 0) {
-      thermalManager.set_temp_fan_speed(pfan, t);
+  const uint8_t index = parser.byteval('I', UINT8_MAX);
+  if (index >= FAN_COUNT) {
+    SERIAL_ECHOLN("Invalid PWM header index");
+    return;
+  }
+
+  const uint16_t pwm = parser.ushortval('P', UINT16_MAX);
+  if (parser.seen_test('P') && !WITHIN(pwm, 0, FAN_MAX_PWM)) {
+    SERIAL_ECHOLN("Invalid PWM");
+    return;
+  }
+
+  if (parser.seen_test('A')) {
+    if (parser.seen_test('P')) {
+      SERIAL_ECHOLN("P and A cannot both be specified");
       return;
     }
-  #endif
+    thermalManager.auto_fan[index] = Temperature::AutoFan::enabled;
+    return;
+  }
 
-  const uint16_t dspeed = parser.seen_test('A') ? thermalManager.fan_speed[active_extruder] : 255;
-
-  uint16_t speed = dspeed;
-
-  // Accept 'I' if temperature presets are defined
-  #if HAS_PREHEAT
-    const bool got_preset = parser.seenval('I');
-    if (got_preset) speed = ui.material_preset[_MIN(parser.value_byte(), PREHEAT_COUNT - 1)].fan_speed;
-  #else
-    constexpr bool got_preset = false;
-  #endif
-
-  if (!got_preset && parser.seenval('S'))
-    speed = parser.value_ushort();
-
-  TERN_(FOAMCUTTER_XYUV, speed *= 2.55f); // Get command in % of max heat
-
-  // Set speed, with constraint
-  thermalManager.set_fan_speed(pfan, speed);
-
-  TERN_(LASER_SYNCHRONOUS_M106_M107, planner.buffer_sync_block(BLOCK_BIT_SYNC_FANS));
-
-  if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
-    thermalManager.set_fan_speed(1 - pfan, speed);
+  /// MarlinBio: This header is being manually controlled, disable auto fan.
+  thermalManager.auto_fan[index] = Temperature::AutoFan::disabled;
+  thermalManager.set_fan_speed(index, pwm);
 }
 
-/**
- * M107: Fan Off
- */
-void GcodeSuite::M107() {
-  const uint8_t pfan = parser.byteval('P', _ALT_P);
-  if (pfan >= _CNT_P) return;
-  if (FAN_IS_REDUNDANT(pfan)) return;
+void GcodeSuite::M106_report(const bool forReplay/*=true*/) {
+  auto header = [](const bool forReplay) {
+    report_echo_start(forReplay);
+    if (!forReplay) SERIAL_ECHOPGM("  ");
+  };
 
-  thermalManager.set_fan_speed(pfan, 0);
+  report_heading(forReplay, FPSTR("M106 - Set PWM"));
 
-  if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
-    thermalManager.set_fan_speed(1 - pfan, 0);
+  header(forReplay);
+  SERIAL_ECHO("  Auto fan: [");
+  FANS_LOOP(f) {
+    SERIAL_ECHO(thermalManager.auto_fan[f] == Temperature::AutoFan::enabled ? "On" : "Off");
+    if (f < FAN_COUNT - 1) SERIAL_ECHOPGM(", ");
+  }
+  SERIAL_ECHOLN("]");
 
-  TERN_(LASER_SYNCHRONOUS_M106_M107, planner.buffer_sync_block(BLOCK_BIT_SYNC_FANS));
+  header(forReplay);
+  SERIAL_ECHO("  PWM:      [");
+  FANS_LOOP(f) {
+    SERIAL_ECHO(thermalManager.fan_speed[f]);
+    if (f < FAN_COUNT - 1) SERIAL_ECHOPGM(", ");
+  }
+  SERIAL_ECHOLN("]");
 }
 
 #endif // HAS_FAN

--- a/Marlin/src/gcode/temp/M155.cpp
+++ b/Marlin/src/gcode/temp/M155.cpp
@@ -33,7 +33,7 @@
 void GcodeSuite::M155() {
 
   if (parser.seenval('S'))
-    thermalManager.auto_reporter.set_interval(parser.value_byte());
+    thermalManager.auto_reporter.set_interval(parser.value_float());
 
 }
 

--- a/Marlin/src/inc/Conditionals-5-post.h
+++ b/Marlin/src/inc/Conditionals-5-post.h
@@ -2612,94 +2612,19 @@
 #endif
 
 #if PIN_EXISTS(HEATER_0)
-  #if defined(COOLER_0_TARGET) && defined(HEATER_0_TARGET)
-    #error "COOLER_0_TARGET and HEATER_0_TARGET cannot both be defined."
-  #elif defined(COOLER_0_TARGET)
-    #define HEATER_0_TARGET 0
-    #define HAS_COOLER_0    1
-    #define HAS_HEATER_0    0
-  #elif defined(HEATER_0_TARGET)
-    #define COOLER_0_TARGET 0
-    #define HAS_HEATER_0    1
-    #define HAS_COOLER_0    0
-  #else
-    #define COOLER_0_TARGET 0
-    #define HEATER_0_TARGET 0
-    #define HAS_COOLER_0    0
-    #define HAS_HEATER_0    0
-  #endif
+  #define HAS_HEATER_0 1
 #endif
 #if PIN_EXISTS(HEATER_1)
-  #if defined(COOLER_1_TARGET) && defined(HEATER_1_TARGET)
-    #error "COOLER_1_TARGET and HEATER_1_TARGET cannot both be defined."
-  #elif defined(COOLER_1_TARGET)
-    #define HEATER_1_TARGET 0
-    #define HAS_COOLER_1    1
-    #define HAS_HEATER_1    0
-  #elif defined(HEATER_1_TARGET)
-    #define COOLER_1_TARGET 0
-    #define HAS_HEATER_1    1
-    #define HAS_COOLER_1    0
-  #else
-    #define COOLER_1_TARGET 0
-    #define HEATER_1_TARGET 0
-    #define HAS_COOLER_1    0
-    #define HAS_HEATER_1    0
-  #endif
+  #define HAS_HEATER_1 1
 #endif
 #if PIN_EXISTS(HEATER_2)
-  #if defined(COOLER_2_TARGET) && defined(HEATER_2_TARGET)
-    #error "COOLER_2_TARGET and HEATER_2_TARGET cannot both be defined."
-  #elif defined(COOLER_2_TARGET)
-    #define HEATER_2_TARGET 0
-    #define HAS_COOLER_2    1
-    #define HAS_HEATER_2    0
-  #elif defined(HEATER_2_TARGET)
-    #define COOLER_2_TARGET 0
-    #define HAS_HEATER_2    1
-    #define HAS_COOLER_2    0
-  #else
-    #define COOLER_2_TARGET 0
-    #define HEATER_2_TARGET 0
-    #define HAS_COOLER_2    0
-    #define HAS_HEATER_2    0
-  #endif
+  #define HAS_HEATER_2 1
 #endif
 #if PIN_EXISTS(HEATER_3)
-  #if defined(COOLER_3_TARGET) && defined(HEATER_3_TARGET)
-    #error "COOLER_3_TARGET and HEATER_3_TARGET cannot both be defined."
-  #elif defined(COOLER_3_TARGET)
-    #define HEATER_3_TARGET 0
-    #define HAS_COOLER_3    1
-    #define HAS_HEATER_3    0
-  #elif defined(HEATER_3_TARGET)
-    #define COOLER_3_TARGET 0
-    #define HAS_HEATER_3    1
-    #define HAS_COOLER_3    0
-  #else
-    #define COOLER_3_TARGET 0
-    #define HEATER_3_TARGET 0
-    #define HAS_COOLER_3    0
-    #define HAS_HEATER_3    0
-  #endif
+  #define HAS_HEATER_3 1
 #endif
 #if PIN_EXISTS(HEATER_4)
-  #if defined(COOLER_4_TARGET) && defined(HEATER_4_TARGET)
-    #error "COOLER_4_TARGET and HEATER_4_TARGET cannot both be defined."
-  #elif defined(COOLER_4_TARGET)
-    #define HEATER_4_TARGET 0
-    #define HAS_COOLER_4    1
-    #define HAS_HEATER_4    0
-  #elif defined(HEATER_4_TARGET)
-    #define COOLER_4_TARGET 0
-    #define HAS_HEATER_4    1
-    #define HAS_COOLER_4    0
-  #else
-    #define COOLER_4_TARGET 0
-    #define HEATER_4_TARGET 0
-    #define HAS_COOLER_4    0
-    #define HAS_HEATER_4    0
-  #endif
+  #define HAS_HEATER_4 1
 #endif
 #if PIN_EXISTS(HEATER_5)
   #define HAS_HEATER_5 1
@@ -2757,7 +2682,7 @@
 #endif
 
 // Thermal protection
-#if ENABLED(THERMAL_PROTECTION_HOTENDS) && WATCH_TEMP_PERIOD > 0
+#if ENABLED(THERMAL_PROTECTION_HOTENDS) && (WATCH_HEAT_PERIOD > 0 || WATCH_COOL_PERIOD > 0)
   #define WATCH_HOTENDS 1
 #endif
 #if ENABLED(THERMAL_PROTECTION_BED) && WATCH_BED_TEMP_PERIOD > 0
@@ -3030,6 +2955,14 @@
   #else
     #define CALC_FAN_SPEED(f) (f ? map(f, 1, 255, FAN_MIN_PWM, FAN_MAX_PWM) : FAN_OFF_PWM)
   #endif
+#endif
+
+#ifndef AUTO_FAN_DAMPEN
+  #define AUTO_FAN_DAMPEN 128
+#elif AUTO_FAN_DAMPEN > FAN_MAX_PWM
+  #define AUTO_FAN_DAMPEN FAN_MAX_PWM
+#elif AUTO_FAN_DAMPEN < 0
+  #define AUTO_FAN_DAMPEN 0
 #endif
 
 // Fan Kickstart

--- a/Marlin/src/libs/autoreport.h
+++ b/Marlin/src/libs/autoreport.h
@@ -26,13 +26,13 @@
 template <typename Helper>
 struct AutoReporter {
   millis_t next_report_ms;
-  uint8_t report_interval;
+  float report_interval;
   #if HAS_MULTI_SERIAL
     SerialMask report_port_mask;
     AutoReporter() : report_port_mask(SerialMask::All) {}
   #endif
 
-  inline void set_interval(uint8_t seconds, const uint8_t limit=60) {
+  inline void set_interval(float seconds, const uint8_t limit=60) {
     report_interval = _MIN(seconds, limit);
     next_report_ms = millis() + SEC_TO_MS(seconds);
   }

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3904,6 +3904,11 @@ void MarlinSettings::reset() {
     //
     TERN_(HAS_HOTEND, gcode.M105(forReplay));
 
+    ///
+    /// MarlinBio: PWM
+    ///
+    TERN_(HAS_FAN, gcode.M106_report(forReplay));
+
     //
     // M149 Temperature units
     //

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -431,7 +431,9 @@ PGMSTR(str_t_cooling_failed, STR_T_COOLING_FAILED);
 // HAS_FAN does not include CONTROLLER_FAN
 #if HAS_FAN
 
-  uint8_t Temperature::fan_speed[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, FAN_OFF_PWM);
+  /// MarlinBio: Set in factory_reset.
+  uint8_t Temperature::fan_speed[FAN_COUNT];
+  Temperature::AutoFan Temperature::auto_fan[FAN_COUNT];
 
   #if ENABLED(EXTRA_FAN_SPEED)
 
@@ -482,8 +484,6 @@ PGMSTR(str_t_cooling_failed, STR_T_COOLING_FAILED);
         return;
       }
     #endif
-
-    TERN_(SINGLENOZZLE, if (fan < EXTRUDERS) fan = 0); // Always fan 0 for SINGLENOZZLE E fan
 
     if (fan >= FAN_COUNT) return;
 
@@ -714,13 +714,22 @@ void Temperature::factory_reset() {
     /// MarlinBio: Heater info
     ///
     #define HEATER_SETUP(e) do { \
-      temp_hotend[e].enabled         = HAS_COOLER_##e || HAS_HEATER_##e; \
-      temp_hotend[e].type            = HAS_COOLER_##e ? HeaterInfo::deviceType::cooler : HeaterInfo::deviceType::heater; \
+      temp_hotend[e].type = HeaterInfo::deviceType::disabled; \
       temp_hotend[e].soft_pwm_amount = 0; \
-      setTargetHotend(HAS_COOLER_##e ? COOLER_##e##_TARGET : HEATER_##e##_TARGET, e); \
+      setTargetHotend(DISABLED_TEMP, e); \
     } while(0);
 
     REPEAT(HOTENDS, HEATER_SETUP)
+  #endif
+
+  #if HAS_FAN
+    ///
+    /// MarlinBio: Fans
+    ///
+    FANS_LOOP(f) {
+      fan_speed[f] = FAN_OFF_PWM;
+      auto_fan[f]  = enabled;
+    }
   #endif
 
   //
@@ -1919,7 +1928,51 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
       //*/
 
     #else // No PID or MPC enabled
-      const float pid_output = temp_hotend[ee].is_off_target() ? BANG_MAX : 0;
+      #define COOL_WINDOW 0.25
+      #define DAMPEN_ON   0.75
+      #define DAMPEN_OFF  0.4
+      #define HEAT_ON     0.4
+      #define HEAT_OFF    0.25
+      #define VERY_BELOW  10
+
+      float           pid_output = 0;
+      celsius_float_t current    = temp_hotend[ee].celsius;
+      celsius_float_t target     = temp_hotend[ee].target;
+
+      /// MarlinBio: Split out heating and cooling for better readability and control.
+      if (temp_hotend[ee].type == hotend_info_t::deviceType::cooler) {
+        if (current > target + COOL_WINDOW) {
+          /// MarlinBio: Turn on when we're above the window.
+          pid_output = BANG_MAX;
+        } else if (current < target - COOL_WINDOW) {
+          /// MarlinBio: Turn off when we're below the window.
+          pid_output = 0;
+        } else {
+          /// MarlinBio: Otherwise, keep the previous setting through the window.
+          pid_output = temp_hotend[ee].soft_pwm_amount ? BANG_MAX : 0;
+        }
+      } else if (temp_hotend[ee].type == hotend_info_t::deviceType::heater) {
+        if (current < target - VERY_BELOW) {
+          /// MarlinBio: Long heats will generate overshoot, try to dampen it by having
+          /// a lower window for the first approach.
+          temp_hotend[ee].dampen_heating = true;
+        }
+        
+        if (temp_hotend[ee].dampen_heating && current > target - DAMPEN_ON && current < target - DAMPEN_OFF) {
+          /// MarlinBio: Turn off early after a long heat.
+          pid_output = 0;
+        } else if (current < target - (temp_hotend[ee].dampen_heating ? DAMPEN_ON : HEAT_ON)) {
+          /// MarlinBio: Turn on when we're well below target.
+          pid_output = BANG_MAX;
+        } else if (current >= target - (temp_hotend[ee].dampen_heating ? DAMPEN_OFF : HEAT_OFF)) {
+          /// MarlinBio: Turn off when we're slightly below target; heat loves to overshoot.
+          temp_hotend[ee].dampen_heating = false;
+          pid_output = 0;
+        } else {
+          /// MarlinBio: Otherwise, keep the previous setting through the window.
+          pid_output = temp_hotend[ee].soft_pwm_amount ? BANG_MAX : 0;
+        }
+      }
     #endif
 
     return pid_output;
@@ -1963,6 +2016,27 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
 
 #if HAS_HOTEND
 
+  bool Temperature::setTypeHotend(const hotend_info_t::deviceType type, const uint8_t E_NAME) {
+    if (type == hotend_info_t::deviceType::disabled) {
+      disable_heater(HOTEND_INDEX);
+      return true;
+    }
+
+    if (!IsRunning()) {
+      SERIAL_ECHOLN("Cannot set module type, device is not running.");
+      return false;
+    }
+
+    if (temp_hotend[HOTEND_INDEX].enabled() && type != temp_hotend[HOTEND_INDEX].type) {
+      SERIAL_ECHOLN("The module is already set to ", temp_hotend[HOTEND_INDEX].type == hotend_info_t::deviceType::cooler ? "cooling." : "heating.",
+        " Disable it first and ensure it is wired in the correct orientation.");
+      return false;
+    }
+
+    temp_hotend[HOTEND_INDEX].type = type;
+    return true;
+  }
+
   /**
    * Manage Hotend Temperatures
    * @brief Task for managing hotends, called from Temperature::task()
@@ -1970,8 +2044,9 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
    */
   void Temperature::manage_hotends(const millis_t &ms) {
     HOTEND_LOOP() {
-      temp_hotend[e].soft_pwm_amount = 0;
-      if (temp_hotend[e].enabled) {
+      uint8_t pwm_amount = 0;
+
+      if (temp_hotend[e].enabled()) {
         #if ENABLED(THERMAL_PROTECTION_HOTENDS)
           const auto deg = degHotend(e);
           if (deg > temp_range[e].maxtemp) {
@@ -1989,27 +2064,25 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
 
         if (   (temp_hotend[e].type == hotend_info_t::deviceType::cooler && temp_hotend[e].celsius > temp_range[e].mintemp)
             || (temp_hotend[e].type == hotend_info_t::deviceType::heater && temp_hotend[e].celsius < temp_range[e].maxtemp)) {
-          temp_hotend[e].soft_pwm_amount = (int)get_pid_output_hotend(e) >> 1;
+          pwm_amount = (int)get_pid_output_hotend(e) >> 1;
         }
 
         #if WATCH_HOTENDS
           /// MarlinBio: Make sure the temperature is near or moving towards the target.
-          if (temp_hotend[e].watch_elapsed(ms)) {
-            if (temp_hotend[e].watch_check())
-              temp_hotend[e].restart_watch();
-            else {
-              TERN_(SOVOL_SV06_RTS, rts.gotoPageBeep(ID_KillHeat_L, ID_KillHeat_D));
-              TERN_(DWIN_CREALITY_LCD, dwinPopupTemperature(0));
-              TERN_(EXTENSIBLE_UI, ExtUI::onHeatingError(e));
-              if (thermalManager.temp_hotend[e].type == hotend_info_t::deviceType::cooler) {
-                _TEMP_ERROR(e, FPSTR(str_t_cooling_failed), MSG_ERR_COOLING_FAILED, temp);
-              } else {
-                _TEMP_ERROR(e, FPSTR(str_t_heating_failed), MSG_ERR_HEATING_FAILED, temp);
-              }
+          if (!temp_hotend[e].watch_check()) {
+            TERN_(SOVOL_SV06_RTS, rts.gotoPageBeep(ID_KillHeat_L, ID_KillHeat_D));
+            TERN_(DWIN_CREALITY_LCD, dwinPopupTemperature(0));
+            TERN_(EXTENSIBLE_UI, ExtUI::onHeatingError(e));
+            if (thermalManager.temp_hotend[e].type == hotend_info_t::deviceType::cooler) {
+              _TEMP_ERROR(e, FPSTR(str_t_cooling_failed), MSG_ERR_COOLING_FAILED, temp);
+            } else {
+              _TEMP_ERROR(e, FPSTR(str_t_heating_failed), MSG_ERR_HEATING_FAILED, temp);
             }
           }
         #endif
       }
+
+      temp_hotend[e].soft_pwm_amount = pwm_amount;
     } // HOTEND_LOOP
   }
 
@@ -2918,24 +2991,15 @@ void Temperature::updateTemperaturesFromRawValues() {
     static constexpr int8_t temp_dir[HOTENDS] = { REPEAT(HOTENDS, _TEMPDIR) };
 
     HOTEND_LOOP() {
-      if (temp_hotend[e].enabled) {
+      if (temp_hotend[e].enabled()) {
         temp_hotend[e].celsius = analog_to_celsius_hotend(temp_hotend[e].getraw(), e);
-
-        #if WATCH_HOTENDS
-          /// MarlinBio: Restart the temperature monitor if this is the first reading, to avoid race conditions.
-          /// Otherwise the monitor might be using an initial temperature of 0.
-          if (!temp_hotend[e].temps_ready) {
-            temp_hotend[e].temps_ready = true;
-            temp_hotend[e].restart_watch();
-          }
-        #endif
 
         const raw_adc_t r = temp_hotend[e].getraw();
         const bool neg = temp_dir[e] < 0, pos = temp_dir[e] > 0;
         if ((neg && r < temp_range[e].raw_max) || (pos && r > temp_range[e].raw_max)) {
           MAXTEMP_ERROR(e, temp_hotend[e].celsius);
         }
-        if (temp_hotend[e].enabled && !is_hotend_preheating(e) && ((neg && r > temp_range[e].raw_min) || (pos && r < temp_range[e].raw_min))) {
+        if (((neg && r > temp_range[e].raw_min) || (pos && r < temp_range[e].raw_min))) {
           MINTEMP_ERROR(e, temp_hotend[e].celsius);
         }
       }
@@ -3115,23 +3179,23 @@ void Temperature::init() {
     HOTEND_LOOP() temp_hotend[e].modeled_block_temp = NAN;
   #endif
 
-  #if HAS_COOLER_0 || HAS_HEATER_0
+  #if HAS_HEATER_0
     #ifdef BOARD_OPENDRAIN_MOSFETS
       OUT_WRITE_OD(HEATER_0_PIN, ENABLED(HEATER_0_INVERTING));
     #else
       OUT_WRITE(HEATER_0_PIN, ENABLED(HEATER_0_INVERTING));
     #endif
   #endif
-  #if HAS_COOLER_1 || HAS_HEATER_1
+  #if HAS_HEATER_1
     OUT_WRITE(HEATER_1_PIN, ENABLED(HEATER_1_INVERTING));
   #endif
-  #if HAS_COOLER_2 || HAS_HEATER_2
+  #if HAS_HEATER_2
     OUT_WRITE(HEATER_2_PIN, ENABLED(HEATER_2_INVERTING));
   #endif
-  #if HAS_COOLER_3 || HAS_HEATER_3
+  #if HAS_HEATER_3
     OUT_WRITE(HEATER_3_PIN, ENABLED(HEATER_3_INVERTING));
   #endif
-  #if HAS_COOLER_4 || HAS_HEATER_4
+  #if HAS_HEATER_4
     OUT_WRITE(HEATER_4_PIN, ENABLED(HEATER_4_INVERTING));
   #endif
   #if HAS_HEATER_5
@@ -3327,13 +3391,6 @@ void Temperature::init() {
     #if _MINMAX_TEST(7, MAX)
       _TEMP_MAX_E(7);
     #endif
-
-    /// MarlinBio: Reset the initial targets after configuring min/max.
-    #define RESET_HOTEND_TARGETS(e) do { \
-      setTargetHotend(HAS_COOLER_##e ? COOLER_##e##_TARGET : HEATER_##e##_TARGET, e); \
-    } while(0);
-
-    REPEAT(HOTENDS, RESET_HOTEND_TARGETS)
   #endif // HAS_HOTEND
 
   // TODO: combine these into the macros above
@@ -3429,10 +3486,10 @@ void Temperature::init() {
     #endif
 
     if (TERN1(THERMAL_PROTECTION_VARIANCE_MONITOR, state != TRMalfunction)) {
-      if (running_temp != target) { // If the target temperature changes, restart
+      if (!temp_hotend[heater_id].enabled() || running_temp != target) { // If the target temperature changes, restart
         running_temp = target;
         state = TRInactive;
-        if (temp_hotend[heater_id].type == heater_info_t::deviceType::cooler ? target < 100 : target > 0) {
+        if (temp_hotend[heater_id].enabled() && target != DISABLED_TEMP) {
           state = TRFirstHeating;
         }
         TERN_(THERMAL_PROTECTION_VARIANCE_MONITOR, variance_timer = 0);
@@ -3497,6 +3554,7 @@ void Temperature::init() {
         #endif
 
         if (temp_hotend[heater_id].type == heater_info_t::deviceType::cooler ? rdiff >= -hysteresis_degc : rdiff <= hysteresis_degc) {
+          // Reset the timer unless we're too above/below target. -hysteresis_degc because a cooling error would be lower - higher < 0.
           timer = now + SEC_TO_MS(period_seconds);
           break;
         }
@@ -3526,23 +3584,28 @@ void Temperature::init() {
 
 #endif // HAS_THERMAL_PROTECTION
 
+void Temperature::disable_heater(heater_id_t e) {
+  #if HAS_HOTEND
+    temp_hotend[e].type = heater_info_t::deviceType::disabled;
+    temp_hotend[e].soft_pwm_amount = 0;
+    setTargetHotend(DISABLED_TEMP, e);
+  #endif
+
+  #if HAS_TEMP_HOTEND
+    #define DISABLE_HEATER(N) if (e == N) WRITE_HEATER_##N(LOW);
+    REPEAT(HOTENDS, DISABLE_HEATER);
+  #endif
+}
+
 void Temperature::disable_all_heaters() {
 
   // Disable autotemp, unpause and reset everything
   TERN_(AUTOTEMP, planner.autotemp.enabled = false);
   TERN_(PROBING_HEATERS_OFF, pause_heaters(false));
 
-  #if HAS_HOTEND
-    HOTEND_LOOP() {
-      temp_hotend[e].enabled = false;
-      temp_hotend[e].soft_pwm_amount = 0;
-    }
-  #endif
-
-  #if HAS_TEMP_HOTEND
-    #define DISABLE_HEATER(N) WRITE_HEATER_##N(LOW);
-    REPEAT(HOTENDS, DISABLE_HEATER);
-  #endif
+  HOTEND_LOOP() {
+    disable_heater(e);
+  }
 
   #if HAS_HEATED_BED
     setTargetBed(0);
@@ -4613,7 +4676,7 @@ void Temperature::isr() {
     header(forReplay);
     SERIAL_ECHO("  Status:       [");
     HOTEND_LOOP() {
-      SERIAL_ECHO(temp_hotend[e].enabled ? (temp_hotend[e].type == hotend_info_t::deviceType::cooler ? "Cooling" : "Heating") : "Disabled");
+      SERIAL_ECHO(temp_hotend[e].enabled() ? (temp_hotend[e].type == hotend_info_t::deviceType::cooler ? "Cooling" : "Heating") : "Disabled");
       if (e < HOTENDS - 1) SERIAL_ECHOPGM(", ");
     }
     SERIAL_ECHOLN("]");
@@ -4621,7 +4684,11 @@ void Temperature::isr() {
     header(forReplay);
     SERIAL_ECHO("  Temperatures: [");
     HOTEND_LOOP() {
-      SERIAL_ECHO(degHotend(e)); // TWR: TODO: p_float_t(c, HEATER_STATE_FLOAT_PRECISION)?
+      if (temp_hotend[e].enabled() && temp_hotend[e].target != DISABLED_TEMP) {
+        SERIAL_ECHO(degHotend(e));
+      } else {
+        SERIAL_ECHO("X");
+      }
       if (e < HOTENDS - 1) SERIAL_ECHOPGM(", ");
     }
     SERIAL_ECHOLN("]");
@@ -4629,7 +4696,11 @@ void Temperature::isr() {
     header(forReplay);
     SERIAL_ECHO("  Targets:      [");
     HOTEND_LOOP() {
-      SERIAL_ECHO(degTargetHotend(e));
+      if (temp_hotend[e].enabled() && temp_hotend[e].target != DISABLED_TEMP) {
+        SERIAL_ECHO(degTargetHotend(e));
+      } else {
+        SERIAL_ECHO("X");
+      }
       if (e < HOTENDS - 1) SERIAL_ECHOPGM(", ");
     }
     SERIAL_ECHOLN("]");

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -59,6 +59,9 @@
 
 typedef int_fast8_t heater_id_t;
 
+/// MarlinBio: Some unrealistic temperature in C.
+#define DISABLED_TEMP -1000
+
 /**
  * States for ADC reading in the ISR
  */
@@ -440,37 +443,52 @@ typedef struct TempInfo {
 /// We also consolidated some of the temperature monitoring here.
 typedef struct HeaterInfo : public TempInfo {
   enum deviceType {
+    disabled,
     heater,
     cooler
   };
 
-  bool            enabled;
+  inline bool enabled() { return type != disabled; }
+
+  bool            dampen_heating;
+  bool            dampen_fan;
   deviceType      type;
   celsius_float_t target;
   uint8_t         soft_pwm_amount;
 
-  bool is_off_target(const celsius_float_t offs=0) const {
-    if (type == heater) return (celsius < target - offs);
-    if (type == cooler) return (celsius > target + offs);
-    return false;
-  }
-
   #if WATCH_HOTENDS
-    bool            temps_ready;
     millis_t        next_ms;
     celsius_float_t watch_target;
 
     inline bool watch_elapsed(const millis_t &ms) { return next_ms && ELAPSED(ms, next_ms); }
     inline bool watch_elapsed() { return watch_elapsed(millis()); }
 
-    inline bool watch_check() { return type == cooler ? celsius <= watch_target : celsius >= watch_target; }
+    bool watch_check() {
+      if (enabled() && next_ms) {
+        /// MarlinBio: Make sure we're not going the wrong way.
+        if (type == cooler ? celsius > watch_target + WATCH_TEMP_DECREASE + THERMAL_PROTECTION_HYSTERESIS : celsius < watch_target - WATCH_TEMP_INCREASE - THERMAL_PROTECTION_HYSTERESIS) {
+          return false;
+        }
+
+        if (watch_elapsed()) {
+          /// MarlinBio: Make sure we reached our target.
+          if (type == cooler ? celsius <= watch_target : celsius >= watch_target) {
+            restart_watch();
+            return true;
+          } else {
+            return false;
+          }
+        }
+      }
+      return true;
+    }
 
     inline void restart_watch() {
-      if (enabled && temps_ready) {
-        const celsius_float_t newtarget = type == cooler ? celsius - WATCH_TEMP_INCREASE : celsius + WATCH_TEMP_INCREASE;
-        if (type == cooler ? newtarget > target + THERMAL_PROTECTION_HYSTERESIS - WATCH_TEMP_INCREASE : newtarget < target - THERMAL_PROTECTION_HYSTERESIS + WATCH_TEMP_INCREASE) {
+      if (enabled()) {
+        const celsius_float_t newtarget = type == cooler ? celsius - WATCH_TEMP_DECREASE : celsius + WATCH_TEMP_INCREASE;
+        if (type == cooler ? newtarget > target + THERMAL_PROTECTION_HYSTERESIS - WATCH_TEMP_DECREASE : newtarget < target - THERMAL_PROTECTION_HYSTERESIS + WATCH_TEMP_INCREASE) {
           watch_target = newtarget;
-          next_ms = millis() + SEC_TO_MS(WATCH_TEMP_PERIOD);
+          next_ms = millis() + SEC_TO_MS(type == cooler ? WATCH_COOL_PERIOD : WATCH_HEAT_PERIOD);
           return;
         }
       }
@@ -786,30 +804,30 @@ class Temperature {
     static millis_t fan_update_ms;
 
     static void manage_extruder_fans(millis_t ms) {
-      #if HAS_FAN_LOGIC
-      if (ELAPSED(ms, fan_update_ms)) { // only need to check fan state very infrequently
-        const millis_t next_ms = ms + fan_update_interval_ms;
-        #if HAS_PWMFANCHECK
-          #define FAN_CHECK_DURATION 100
-          if (fan_check.is_measuring()) {
-            fan_check.compute_speed(ms + FAN_CHECK_DURATION - fan_update_ms);
-            fan_update_ms = next_ms;
-          }
-          else
-            fan_update_ms = ms + FAN_CHECK_DURATION;
-          fan_check.toggle_measuring();
-        #else
-          TERN_(HAS_FANCHECK, fan_check.compute_speed(next_ms - fan_update_ms));
-          fan_update_ms = next_ms;
-        #endif
-        TERN_(HAS_AUTO_FAN, update_autofans()); // Needed as last when HAS_PWMFANCHECK to properly force fan speed
-      }
-      #endif
-
-      #if HAS_HOTEND
+      #if HAS_HOTEND && HAS_FAN
         HOTEND_LOOP() {
-          /// MarlinBio: If the cooler is running, turn the fans on.
-          set_fan_speed(e, temp_hotend[e].type == hotend_info_t::deviceType::cooler && temp_hotend[e].enabled ? FAN_MAX_PWM : 0);
+          if (auto_fan[e] == enabled) {
+            float fan_scale = 0;
+            if (temp_hotend[e].type == hotend_info_t::deviceType::cooler) {
+              if (temp_hotend[e].celsius < temp_hotend[e].target) {
+                /// MarlinBio: When we reach the target, turn on fan dampening.
+                temp_hotend[e].dampen_fan = true;
+              } else if (temp_hotend[e].celsius > temp_hotend[e].target + THERMAL_PROTECTION_HYSTERESIS) {
+                /// MarlinBio: Turn off fan dampening if we drift too far above target (it also starts disabled after setting a new target).
+                temp_hotend[e].dampen_fan = false;
+              }
+
+              if (temp_hotend[e].dampen_fan) {
+                fan_scale = float(AUTO_FAN_DAMPEN) / FAN_MAX_PWM;
+              } else {
+                /// MarlinBio: Adjust the PWM based on the target, max at -10C linearly scaled to off at 90C.
+                fan_scale = (90 - temp_hotend[e].target) * .01;
+                NOMORE(fan_scale, 1);
+                NOLESS(fan_scale, 0);
+              }
+            }
+            set_fan_speed(e, FAN_MAX_PWM * fan_scale);
+          }
         }
       #endif
     }
@@ -886,6 +904,14 @@ class Temperature {
     #if HAS_FAN
 
       static uint8_t fan_speed[FAN_COUNT];
+  
+      /// MarlinBio: Auto fan is disabled forever when M106 is run.
+      enum AutoFan {
+        enabled,
+        disabled
+      };
+      static AutoFan auto_fan[FAN_COUNT];
+
       #define FANS_LOOP(I) for (uint8_t I = 0; I < FAN_COUNT; ++I)
 
       static void set_fan_speed(const uint8_t fan, const uint16_t speed);
@@ -1004,6 +1030,8 @@ class Temperature {
 
     #if HAS_HOTEND
 
+      static bool setTypeHotend(const hotend_info_t::deviceType type, const uint8_t E_NAME);
+
       static void setTargetHotend(const celsius_float_t celsius, const uint8_t E_NAME) {
         const uint8_t ee = HOTEND_INDEX;
         #if PREHEAT_TIME_HOTEND_MS > 0
@@ -1013,7 +1041,15 @@ class Temperature {
             start_hotend_preheat_time(ee);
         #endif
         TERN_(AUTO_POWER_CONTROL, if (celsius) powerManager.power_on());
-        temp_hotend[ee].target = temp_hotend[ee].type == hotend_info_t::deviceType::cooler ? _MAX(celsius, temp_range[ee].mintemp + HOTEND_OVERSHOOT) : _MIN(celsius, temp_range[ee].maxtemp - HOTEND_OVERSHOOT);
+
+        if (temp_hotend[ee].enabled()) {
+          temp_hotend[ee].target = temp_hotend[ee].type == hotend_info_t::deviceType::cooler ? _MAX(celsius, temp_range[ee].mintemp + HOTEND_OVERSHOOT) : _MIN(celsius, temp_range[ee].maxtemp - HOTEND_OVERSHOOT);
+        } else {
+          temp_hotend[ee].target = DISABLED_TEMP;
+        }
+
+        temp_hotend[ee].dampen_fan     = false;
+        temp_hotend[ee].dampen_heating = false;
         TERN_(WATCH_HOTENDS, temp_hotend[ee].restart_watch());
       }
 
@@ -1175,6 +1211,11 @@ class Temperature {
      * The software PWM power for a heater
      */
     static int16_t getHeaterPower(const heater_id_t heater_id);
+
+    /**
+     * Switch off one heater
+     */
+    static void disable_heater(heater_id_t e);
 
     /**
      * Switch off all heaters, set all target temperatures to 0

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1129,6 +1129,13 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     // Nothing to do
     UNUSED(new_tool); UNUSED(no_move);
   
+  #elif !HAS_MULTI_EXTRUDER
+
+    UNUSED(no_move);
+
+    if (new_tool) invalid_extruder_error(new_tool);
+      return;
+
   #else
 
   /// MarlinBio: "if constexpr" will not compile the block that won't be run.
@@ -1159,7 +1166,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
         kill(F("A Z axis raise is specified but the Z axes were not homed"));
       }
       #if HAS_HOTEND_OFFSET
-        if (    (hotend_offset[new_tool].x - hotend_offset[old_tool].x != 0 && !axis_was_homed(X_AXIS))
+        if (   (hotend_offset[new_tool].x - hotend_offset[old_tool].x != 0 && !axis_was_homed(X_AXIS))
             || (hotend_offset[new_tool].y - hotend_offset[old_tool].y != 0 && !axis_was_homed(Y_AXIS))
             || (hotend_offset[new_tool].z - hotend_offset[old_tool].z != 0 && !axis_was_homed(Z_AXIS))) {
           kill(F("A hotend offset is specified but the axes were not homed"));


### PR DESCRIPTION
We've update the temperature control logic to allow setting the temperature modules to heating, cooling, or disabled using G-code. This is helpful for those who cannot rebuild the firmware, and rely on pre-built binaries.

We also updated the fan logic a bit to allow users to use M106 to set PWM manually and disable the automatic fan control, and also to reenable it after it has been disabled. This is useful for those who want more control over their fan profile for cooling.